### PR TITLE
Fixing vim normal mode cursor color

### DIFF
--- a/Nord.rstheme
+++ b/Nord.rstheme
@@ -24,7 +24,7 @@
 .normal-mode .ace_cursor {
     border: 0!important;
     background-color: #d8dee9;
-    opacity: 0.5 !important;
+    opacity: 0.75 !important;
 }
 
 .ace_marker-layer .ace_selection {

--- a/Nord.rstheme
+++ b/Nord.rstheme
@@ -22,12 +22,9 @@
 }
 
 .normal-mode .ace_cursor {
-
     border: 0!important;
-
     background-color: #d8dee9;
-
-    opacity: 0.5;
+    opacity: 0.1;
 }
 
 .ace_marker-layer .ace_selection {

--- a/Nord.rstheme
+++ b/Nord.rstheme
@@ -21,6 +21,15 @@
   color: #d8dee9;
 }
 
+.normal-mode .ace_cursor {
+
+    border: 0!important;
+
+    background-color: #d8dee9;
+
+    opacity: 0.5;
+}
+
 .ace_marker-layer .ace_selection {
   background: rgba(67, 76, 94, 0.80);
 }

--- a/Nord.rstheme
+++ b/Nord.rstheme
@@ -24,7 +24,7 @@
 .normal-mode .ace_cursor {
     border: 0!important;
     background-color: #d8dee9;
-    opacity: 0.1;
+    opacity: 0.5 !important;
 }
 
 .ace_marker-layer .ace_selection {


### PR DESCRIPTION
The color in normal vim mode is red which doesn't fit thus this pull request changes the color to white with 0.75 opacity